### PR TITLE
fix- exactly same video_id and video_hash 

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -44,6 +44,21 @@ impl VideoHashIndex {
         Ok(())
     }
 
+    pub fn has_exact_match(
+        &self,
+        video_id: &str,
+        hash: &VideoHash,
+    ) -> Result<bool, Box<dyn Error + Send + Sync>> {
+        let hash_value = binary_string_to_u64(&hash.hash)?;
+
+        let hashes = self.hashes.read().unwrap();
+        if let Some(&existing_hash) = hashes.get(video_id) {
+            return Ok(existing_hash == hash_value);
+        }
+
+        Ok(false)
+    }
+
     fn ensure_index_built(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
         let mut index_lock = self.index.write().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,24 @@ pub async fn search(
         }
     };
 
+    let has_exact_match = match index.has_exact_match(&req.video_id, &query_hash) {
+        Ok(exists) => exists,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to check for exact match: {}", e),
+            });
+        }
+    };
+
+    if has_exact_match {
+        return HttpResponse::Ok().json(SearchResponse {
+            match_found: false,
+            match_details: None,
+            hash_added: false,
+        });
+    }
+
+    // Continue with the existing similarity search logic
     let similar_hashes = match index.find_within_distance(&query_hash, MAX_HAMMING_DISTANCE) {
         Ok(results) => results,
         Err(e) => {


### PR DESCRIPTION
fix- if there is request with exactly same video_id and video_hash then response was match found but this need to be match not found, as downstream implementation breaks if this happens